### PR TITLE
Fix potential HTTP error in axolotl command

### DIFF
--- a/cogs/error_handler.py
+++ b/cogs/error_handler.py
@@ -1,6 +1,7 @@
-import discord
-import traceback
 import sys
+import traceback
+
+import discord
 from discord.ext import commands
 
 
@@ -24,7 +25,7 @@ class CommandErrorHandler(commands.Cog):
 
         cog = ctx.cog
         if cog:
-            if cog._get_overridden_method(cog.cog_command_error) is not None:
+            if cog._get_overridden_method(cog.cog_command_error) is not None:  # noqa
                 return
 
         ignored = (commands.CommandNotFound, )

--- a/cogs/example_requests.py
+++ b/cogs/example_requests.py
@@ -23,8 +23,10 @@ class ExampleRequests(commands.Cog):
                 embed.set_image(url=response_json.get("url"))  # sets the embed image with the url returned by the api
 
                 # adds a footer to the embed, the icon_url parameter takes any url with an image in it.
-                embed.set_footer(text="Command made by leowonardo#2443",
-                                 icon_url="https://en.gravatar.com/userimage/171548483/05a79763322fb378f65535c1054e8d82.jpeg")
+                embed.set_footer(
+                    text="Command made by leowonardo#2443",
+                    icon_url="https://en.gravatar.com/userimage/171548483/05a79763322fb378f65535c1054e8d82.jpeg"
+                )
 
                 await ctx.reply(embed=embed, mention_author=False)
 

--- a/cogs/example_requests.py
+++ b/cogs/example_requests.py
@@ -14,7 +14,11 @@ class ExampleRequests(commands.Cog):
     async def axolotl(self, ctx):
         async with aiohttp.ClientSession() as session:
             async with session.get(f"https://axoltlapi.herokuapp.com/") as response:
-                response_json = await response.json()
+                try:
+                    response.raise_for_status()
+                    response_json = await response.json()
+                except aiohttp.ClientResponseError:
+                    return await ctx.send('Unable to connect to the server! Please wait a while and try again.')
                 embed = discord.Embed(
                     color=ctx.me.color,  # defines the embed color as the bot's color in the server
                     description=response_json.get("facts"),


### PR DESCRIPTION
When using the `axolotl` command while the endpoint is dead, the bot sends a cryptic message.
![image](https://user-images.githubusercontent.com/13762043/139574868-126f4987-54cc-4cd4-859d-9583b31fb761.png)

This PR adds a error handler to catch for HTTP errors before parsing the JSON response in order to prevent the above situation from happening:

![image](https://user-images.githubusercontent.com/13762043/139574935-fddb1bf2-5db9-40db-b5a9-9257e7acb4b3.png)
